### PR TITLE
macOS section title duplicated

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -58,7 +58,7 @@ $ brew tap ethereum/ethereum
 $ brew install ethereum
 ```
 
-On a macOS:
+On linux:
 
 ``` linux
 $ sudo add-apt-repository -y ppa:ethereum/ethereum


### PR DESCRIPTION
The `With Ethereum Support` part has 2 paragraphs both with title `macOS`:

<img width="604" alt="screen shot 2018-05-05 at 01 09 00" src="https://user-images.githubusercontent.com/1059/39656537-ec7f7b06-5000-11e8-8961-569c669caaa6.png">

I set `linux` in the second one, but maybe it should be `ubuntu` or `debian`?