### PR TITLE
spec current node.js LTS as requirement

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -39,7 +39,7 @@ It only takes a few minutes to set up Embark. If you encounter a problem and can
 
 Installing Embark is quite easy. However, you do need to have a couple of other things installed first:
 
-- [Node.js](http://nodejs.org/) 8.10 or higher
+- [Node.js](http://nodejs.org/) 8.11.3 LTS or higher
 
 After installing nodejs you can install embark with:
 


### PR DESCRIPTION
Per team discussion: specify the current LTS as the minimum supported version.

Should there be a deployment checklist for `embark-site`, with a reminder to check whether the current LTS version has been bumped since the last time changes went live?  I'm not (yet) familiar with hexo, but perhaps the current LTS version number can be determined and inserted during `hexo generate`?