### PR TITLE
Fix references to OpenZeppelin package

### DIFF
--- a/source/_posts/2018-05-04-embark-3-0-released.md
+++ b/source/_posts/2018-05-04-embark-3-0-released.md
@@ -84,7 +84,7 @@ Embark is smart enough to take care of the dependencies of the resources and pre
         "file": "github.com/status/contracts/contracts/identity/ERC725.sol"
       },
       "Ownable": {
-        "file": "https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/ownership/Ownable.sol"
+        "file": "https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/ownership/Ownable.sol"
       },
       "SimpleStorage": {
         "file": "./some_folder/simple_storage.sol"
@@ -101,7 +101,7 @@ You can also import the same URIs directly in solidity which is quite useful for
 ```Javascript
 import "git://github.com/status/contracts/contracts/identity/ERC725.sol#develop";
 import "github.com/status/contracts/contracts/identity/ERC725.sol";
-import "https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/ownership/Ownable.sol"
+import "https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/ownership/Ownable.sol"
 
 contract MyContract is Ownable {
   ...
@@ -117,7 +117,7 @@ You can now install npm packages that contain contracts (e.g `npm install --save
   "development": {
     "contracts": {
       "ERC20": {
-        file: "zeppelin-solidity/contracts/token/ERC20/ERC20.sol"
+        file: "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol"
       }
     }
   }

--- a/source/docs/contracts_configuration.md
+++ b/source/docs/contracts_configuration.md
@@ -206,7 +206,7 @@ module.exports = {
         <mark class="highlight-inline">"file": "github.com/status/contracts/contracts/identity/ERC725.sol"</mark>
       },
       "Ownable": {
-        <mark class="highlight-inline">"file": "https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/ownership/Ownable.sol"</mark>
+        <mark class="highlight-inline">"file": "https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/ownership/Ownable.sol"</mark>
       }
     }
   }
@@ -223,7 +223,7 @@ module.exports = {
     "gas": "auto",
     "contracts": {
       "ERC20": {
-        <mark class="highlight-inline">"file": "zeppelin-solidity/contracts/token/ERC20/ERC20.sol"</mark>
+        <mark class="highlight-inline">"file": "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol"</mark>
       }
     }
   }

--- a/source/docs/contracts_imports.md
+++ b/source/docs/contracts_imports.md
@@ -9,12 +9,12 @@ If using solidity it's also possible to directly import contract files inside th
 
 You can also import a contract file from a npm package:
 
-<pre><code class="solidity">import "zeppelin-solidity/contracts/ownership/Ownable.sol";</code></pre>
+<pre><code class="solidity">import "openzeppelin-solidity/contracts/ownership/Ownable.sol";</code></pre>
 
 You can even use files directly from Git, Github or directly from HTTP(S):
 
 <pre><code class="solidity">import "git://github.com/status/contracts/contracts/identity/ERC725.sol#develop";
 import "github.com/status/contracts/contracts/identity/ERC725.sol";
-import "https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/ownership/Ownable.sol";
+import "https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/ownership/Ownable.sol";
 </code></pre>
 


### PR DESCRIPTION
The repo and npm package were renamed to `openzeppelin-solidity` a while ago.

As a side note, we discourage using the `master` branch directly. We have versioned releases which is what users should be using. It's possible to change the `/blob/master` part in the URL imports to `/blob/vX.Y.Z` in your docs, but I didn't want to do that because it will become outdated with time.