### PR TITLE
revise wording re: `embark test` options

### DIFF
--- a/source/docs/contracts_testing.md
+++ b/source/docs/contracts_testing.md
@@ -8,7 +8,7 @@ Testing Ethereum Contracts
 
 You can run specs with ``embark test``. Invoking this command runs all the test files under ``test/``. You can also run a specific test file with `embark test <path/test_filename.js>`.
 
-Pass the `--gasDetails` option to `embark test` to have the gas cost printed for each contract deployment.
+Pass the `--gasDetails` option to `embark test` to have the gas cost printed for each contract deployment when running the tests.
 
 By default, tests are run using an Ethereum simulator (ganache). You can use the `--node` option to change that behavior. Passing `--node embark` to `embark test` will use the Ethereum node associated with an already running embark process. You can also specify a custom endpoint, for example:
 `embark test --node ws://localhost:8556`.

--- a/source/docs/embark_commands.md
+++ b/source/docs/embark_commands.md
@@ -89,17 +89,17 @@ Runs Tests. If `file` is not specified then it will run all the tests inside the
 
 Option | Description
 --- | ---
-`-n`, `--node` | node to connect to (default: vm)
-`-d`, `--gasDetails` | print the gas cost for each contract deployment
-`-c`, `--coverage` | generate solidity coverage report
+`-n`, `--node` | node for running the tests (default: vm)
+`-d`, `--gasDetails` | print the gas cost for each contract deployment when running the tests
+`-c`, `--coverage` | generate a coverage report after running the tests (vm only)
 
 The `--node` option supports several values:
 
 Value | Description
 --- | ---
-`vm` | starts an Ethereum simulator (ganache) and runs the tests using the simulator
-`embark` | uses the node associated with an already running embark process
-`<endpoint>` | connects to a running node available at the endpoint and uses it to run the tests
+`vm` | start and use an Ethereum simulator (ganache)
+`embark` | use the node of a running embark process
+`<endpoint>` | connect to and use the specified node
 
 Example of endpoint usage: `embark test --node ws://localhost:8556`
 


### PR DESCRIPTION
Make the wording match the revisions of https://github.com/embark-framework/embark/pull/869.