### PR TITLE
Fix documentation typos

### DIFF
--- a/source/docs/configuration.md
+++ b/source/docs/configuration.md
@@ -57,7 +57,7 @@ This is the location of the config files, if it is:
 
 ### library versions
 
-Here you can optionaly specify the versions of the library to be used by Embark. Embark will automatically download the specific library version if necessary. It's possible to override this in other config files such as `contracts.json` on a per enviroment basis.
+Here you can optionally specify the versions of the library to be used by Embark. Embark will automatically download the specific library version if necessary. It's possible to override this in other config files such as `contracts.json` on a per enviroment basis.
 
 ### plugins
 

--- a/source/docs/environments.md
+++ b/source/docs/environments.md
@@ -1,7 +1,7 @@
 title: Environments
 ---
 
-Developing on Ethereum require you to #buidl everything locally, then deploy it on various test networks, and only then get to the big show. Setting up connections and deploying contracts easily to all these different environments is a pain. But do not fear, Embark has you covered. We use the concept of `environments`, which means that every config file has entries for each environment so you can control them all sensibly from one place that can be specified in most embark commands.
+Developing on Ethereum requires you to #buidl everything locally, then deploy it on various test networks, and only then get to the big show. Setting up connections and deploying contracts easily to all these different environments is a pain. But do not fear, Embark has you covered. We use the concept of `environments`, which means that every config file has entries for each environment so you can control them all sensibly from one place that can be specified in most embark commands.
 
 ### Configuration
 


### PR DESCRIPTION
Fixes a couple of typos I noticed while reading the Embark docs.