### PR TITLE
docs(guides/installation): introduce sections for nightlies and dev branch

### DIFF
--- a/source/docs/installation.md
+++ b/source/docs/installation.md
@@ -3,7 +3,7 @@ title: Installation
 
 ## Prerequisites
 
-In order to make Embark work in your computer, we need to have some tools installed first. Make sure you have the following ready and in the correct version:
+In order to make Embark work on our computer, we need to have some tools installed first. Make sure you have the following ready and in the correct version:
 
 - [Node](#Node)
 - [Ethereum Client](#Ethereum-Client-Optional)
@@ -18,7 +18,7 @@ Please install [Node.js](http://nodejs.org/) in version 8.11.3 LTS or higher.
 {% note info Quick tip: %}
 **We recommend installing Node using the [Node Version Manager](https://github.com/creationix/nvm/blob/master/README.md).**  This is because it makes it very easy to install different versions of Node in isolated environments that don't require users to [change their permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) when installing packages. Find instructions on how to install NVM [here](https://github.com/creationix/nvm/blob/master/README.md#install-script).
 
-Once that is done, you can install and select a specific Node version or use the `--lts` option to get the latest version with long term support like this:
+Once that is done, we can install and select a specific Node version or use the `--lts` option to get the latest version with long term support like this:
 
 <pre><code class="shell">$ nvm install --lts
 $ nvm use --lts
@@ -28,7 +28,7 @@ $ nvm use --lts
 
 ### IPFS (Optional)
 
-IPFS can be used to distribute your application's content on the decentralized IPFS nodes. This can be skipped in case this isn't planned, however we do recommend it. Checkout IPFS' [installation guide](https://docs.ipfs.io/introduction/install/) to learn how to install IPFS on your local machine.
+IPFS can be used to distribute our application's content on the decentralized IPFS nodes. This can be skipped in case this isn't planned, however we do recommend it. Checkout IPFS' [installation guide](https://docs.ipfs.io/introduction/install/) to learn how to install IPFS on our local machine.
 
 To verify that the installation was successful, simply run the following command:
 
@@ -40,9 +40,9 @@ This outputs something like
 
 ### Ethereum Client (Optional)
 
-Embark can spin up an Ethereum node for you. To make this happen, an Ethereum client has to be installed on your machine as well. Embark already comes with [Ganache CLI](https://truffleframework.com/ganache), a blockchain node emulator, which is accessible via [Embark's simulator](embark_commands.html#simulator) command.
+Embark can spin up an Ethereum node for us. To make this happen, an Ethereum client has to be installed on our machine as well. Embark already comes with [Ganache CLI](https://truffleframework.com/ganache), a blockchain node emulator, which is accessible via [Embark's simulator](embark_commands.html#simulator) command.
 
-In case you want to run a real node, [geth](https://geth.ethereum.org/) is a pretty good one. Check out the [installation guide](https://ethereum.github.io/go-ethereum/install/) for your platform and verify your installation with:
+In case we want to run a real node, [geth](https://geth.ethereum.org/) is a pretty good one. Check out the [installation guide](https://ethereum.github.io/go-ethereum/install/) for our platform and verify our installation with:
 
 <pre><code class="shell">$ geth version</code></pre>
 
@@ -67,17 +67,29 @@ We can install Embark using the Node Package Manager (no worries, that one comes
 
 <pre><code class="shell">$ npm -g install embark</code></pre>
 
-If you want to have access to Embark 4 alpha, do this instead:
-
-<pre><code class="shell">$ npm -g install embark@next</code></pre>
-
-After that, `embark` should be available as a global command in your terminal of choice. Let's verify this by running the following command:
+After that, `embark` should be available as a global command in our terminal of choice. Let's verify this by running the following command:
 
 <pre><code class="shell">$ embark --version</code></pre>
 
 At the time of writing this guide, the output looked like this:
 
 <pre><code class="shell">3.2.1</code></pre>
+
+## Installing Embark @next
+
+While running `npm install -g embark` will give us the latest and great stable version of Embark, we're sometimes interested in trying out features that are in active development. The Embark team maintains a `next` distribution tag on npm that can be used to install versions of Embark that aren't stable.
+
+<pre><code class="shell">$ npm -g install embark@next</code></pre>
+
+## Installing Embark's latest GitHub version
+
+If we're interested in getting whatever has landed last in the code base, we can install directly from Embark's GitHub repository like this:
+
+<pre><code class="shell">$ npm -g install embark-framework/embark</code></pre>
+
+{% note warn Warning: %}
+Installations with `@next` or directly from the `develop` branch on GitHub are considered unstable and may have bugs, so please proceed with caution.
+{% endnote %}
 
 Awesome! We're all set up. Let's build our first decentralized application!
 


### PR DESCRIPTION
As commented in https://github.com/embark-framework/embark-site/pull/92#discussion_r230050759, `npm install -g embark@next` will result in different versions in the future where `4.00-alpha.1` is not "relevant" anymore.

Therefore, this PR updates the installation guide to ensure that the docs are timeless.