### PR TITLE
Add Alchemy Insights API endopints

### DIFF
--- a/source/docs/contracts_deployment.md
+++ b/source/docs/contracts_deployment.md
@@ -170,3 +170,21 @@ module.exports = {
   }
 }
 </code></pre>
+
+## Testnet and Mainnet API Endpoints
+
+Alchemy Insights are offering a preview of their API that we can use for deploying to and interacting with our contracts on testnet (Rinkeby, Ropsten, and Kovan) and mainnet. The following endpoints are available for our use.
+
+{% note info No websockets support %}
+Please note that these endpoints currently do not support websockets. There are plans to support websockets in the future.
+
+If your dApp relies on websockets use, please use another API endpoint such as Infura.
+{% endnote %}
+
+#### Alchemy Insights Endpoints
+<pre><code class="javascript">
+Mainnet: https://eth-mainnet.alchemyapi.io/jsonrpc/8a9fRmi8wx5BrSOOqKa6-3nFHMHYRvmH
+Kovan: https://eth-kovan.alchemyapi.io/jsonrpc/8a9fRmi8wx5BrSOOqKa6-3nFHMHYRvmH
+Rinkeby: https://eth-rinkeby.alchemyapi.io/jsonrpc/8a9fRmi8wx5BrSOOqKa6-3nFHMHYRvmH
+Ropsten: https://eth-ropsten.alchemyapi.io/jsonrpc/8a9fRmi8wx5BrSOOqKa6-3nFHMHYRvmH
+</code></pre>


### PR DESCRIPTION
Add Alchemy Insights API endpoints as an alternative to Infura. It's not very prominent, but I honestly don't know how many people will use it without websockets support.

My only concern here is that we are kind of promoting something that isn't really open source... they plan to open the API source up in the future, but currently it's not open.