### PR TITLE
fix(@embark/embark-site): Fix vortex template snippet

### DIFF
--- a/source/_data/templates.yml
+++ b/source/_data/templates.yml
@@ -48,7 +48,7 @@
 - name: Embark Vortex Template
   description: A React Application showing what can be done with Vortex when using Embark.
   thumbnail: vortex.png
-  install: embark new AppName --template Horyus/vortex-demo-embark/
+  install: embark new AppName --template Horyus/vortex-demo-embark
   link: https://github.com/Horyus/vortex-demo-embark/
   tags:
     - react


### PR DESCRIPTION
Attempting to run the snippet as presenting causes an error in the terminal.

Remove the trailing slash from the template URL in the vortex snippet.