### PR TITLE
fix(@embark-site): Temporarily remove Vortex template

### DIFF
--- a/source/_data/templates.yml
+++ b/source/_data/templates.yml
@@ -45,13 +45,13 @@
 #    - angular.js
 #    - frontend
 
-- name: Embark Vortex Template
-  description: A React Application showing what can be done with Vortex when using Embark.
-  thumbnail: vortex.png
-  install: embark new AppName --template Horyus/vortex-demo-embark
-  link: https://github.com/Horyus/vortex-demo-embark/
-  tags:
-    - react
+# - name: Embark Vortex Template
+#   description: A React Application showing what can be done with Vortex when using Embark.
+#   thumbnail: vortex.png
+#   install: embark new AppName --template Horyus/vortex-demo-embark
+#   link: https://github.com/Horyus/vortex-demo-embark/
+#   tags:
+#     - react
 
 - name: Bamboo Template
   description: Template to demonstrate use of the Bamboo contracts


### PR DESCRIPTION
Vortex is currently undergoing an overhaul and the Vortex demo with Embark is not working properly. The thinking is to de-list this template until Vortex is in a working state.