### PR TITLE
docs(@templates): shorten ethvtx description

### DIFF
--- a/source/_data/templates.yml
+++ b/source/_data/templates.yml
@@ -45,8 +45,8 @@
 #    - angular.js
 #    - frontend
 
-- name: Embark x ΞVTX Template
-  description: An Embark template showcasing the features of ethvtx. ethvtx is an Ethereum-ready DApp Redux store. It will manage all the data and interactions between your user and the Ethereum Blockchain and is perfectly suited for React DApps.
+- name: ethvtx Template
+  description: Demo app for ethvtx, an Ethereum-Ready & Framework-Agnostic Redux configuration
   thumbnail: vortex.png
   install: embark new AppName --template Horyus/ethvtx_embark
   link: https://github.com/Horyus/ethvtx_embark


### PR DESCRIPTION
  - The title is shorter and contains no more special characters.
  - The description is shorter to match other templates sizes.
  - Lowercase name by choice