### PR TITLE
Fixed a small typo

### DIFF
--- a/source/docs/contracts_testing.md
+++ b/source/docs/contracts_testing.md
@@ -85,7 +85,7 @@ config({
   }
 });
 
-contract('SomContract', () => {
+contract('SomeContract', () => {
   ...
 });
 ```


### PR DESCRIPTION
I was going through the documentation and found out that the reference to the contract declaration has a typo. Name of the contract is "SomeContract" but is referenced with "SomContract". I tried looking at it twice just to make sure it wasn't declared with "SomContract", it'd have worked in that case. Thank you for considering this pull request. 😄 